### PR TITLE
feat : manual coverage implemented binary search: closes #4

### DIFF
--- a/src/main/java/com/thealgorithms/searches/BinarySearch2dArray.java
+++ b/src/main/java/com/thealgorithms/searches/BinarySearch2dArray.java
@@ -97,16 +97,13 @@ public class BinarySearch2dArray {
         int colEnd
     ) {
         while (colStart <= colEnd) {
-            branchesReached.add("8.1");
             int midIndex = colStart + (colEnd - colStart) / 2;
 
             if (arr[row][midIndex] == target) {
-                branchesReached.add("8.1.1");
                 return new int[] {
                 row,
                 midIndex, }; 
             } else if (arr[row][midIndex] < target) { 
-                branchesReached.add("8.1.2");
                 colStart = midIndex + 1; 
             } else {
                 colEnd = midIndex - 1;

--- a/src/main/java/com/thealgorithms/searches/BinarySearch2dArray.java
+++ b/src/main/java/com/thealgorithms/searches/BinarySearch2dArray.java
@@ -1,4 +1,5 @@
 package com.thealgorithms.searches;
+import java.util.HashSet;
 
 /*
 To apply this method, the provided array must be strictly sorted. In this method, two pointers, one at 0th row
@@ -9,60 +10,83 @@ greater than the target, then the rows below it are ignored.
  */
 public class BinarySearch2dArray {
 
+    public static HashSet<String> branchesReached = new HashSet<>();
     static int[] BinarySearch(int[][] arr, int target) {
         int rowCount = arr.length, colCount = arr[0].length;
 
         if (rowCount == 1) {
+            branchesReached.add("1.1");
             return binarySearch(arr, target, 0, 0, colCount);
         }
 
         int startRow = 0, endRow = rowCount - 1, midCol = colCount / 2;
 
         while (startRow < endRow - 1) {
+            branchesReached.add("2.1");
             int midRow = startRow + (endRow - startRow) / 2; //getting the index of middle row
 
             if (arr[midRow][midCol] == target) {
+                branchesReached.add("2.1.1");
                 return new int[] { midRow, midCol };
-            } else if (arr[midRow][midCol] < target) startRow =
-                midRow; else endRow = midRow;
+            } else if (arr[midRow][midCol] < target) {
+                branchesReached.add("2.1.2");
+                startRow = midRow; 
+            } else {
+                branchesReached.add("2.1.3");
+                endRow = midRow;
+            }
+            
         }
         /*
             if the above search fails to find the target element, these conditions will be used to find the target
             element, which further uses the binary search algorithm in the places which were left unexplored.
              */
-        if (arr[startRow][midCol] == target) return new int[] {
-            startRow,
-            midCol,
-        };
+        if (arr[startRow][midCol] == target) { 
+            branchesReached.add("3.1");
+            return new int[] {startRow, midCol};
+        }
 
-        if (arr[endRow][midCol] == target) return new int[] { endRow, midCol };
+        if (arr[endRow][midCol] == target){
+            branchesReached.add("4.1");
+            return new int[] { endRow, midCol };
+        }
 
-        if (target <= arr[startRow][midCol - 1]) return binarySearch(
+        if (target <= arr[startRow][midCol - 1]) {
+            branchesReached.add("5.1");
+         return binarySearch(
             arr,
             target,
             startRow,
             0,
             midCol - 1
         );
+        }
 
         if (
             target >= arr[startRow][midCol + 1] &&
             target <= arr[startRow][colCount - 1]
-        ) return binarySearch(arr, target, startRow, midCol + 1, colCount - 1);
+        ) {
+            branchesReached.add("6.1");
+            return binarySearch(arr, target, startRow, midCol + 1, colCount - 1);
+        }
 
-        if (target <= arr[endRow][midCol - 1]) return binarySearch(
+        if (target <= arr[endRow][midCol - 1]) {
+            branchesReached.add("7.1");
+            return binarySearch(
             arr,
             target,
             endRow,
             0,
             midCol - 1
-        ); else return binarySearch(
-            arr,
-            target,
-            endRow,
-            midCol + 1,
-            colCount - 1
-        );
+        ); } else { 
+                branchesReached.add("7.2");
+                return binarySearch(
+                arr,
+                target,
+                endRow,
+                midCol + 1,
+                colCount - 1); 
+        }
     }
 
     static int[] binarySearch(
@@ -73,13 +97,20 @@ public class BinarySearch2dArray {
         int colEnd
     ) {
         while (colStart <= colEnd) {
+            branchesReached.add("8.1");
             int midIndex = colStart + (colEnd - colStart) / 2;
 
-            if (arr[row][midIndex] == target) return new int[] {
+            if (arr[row][midIndex] == target) {
+                branchesReached.add("8.1.1");
+                return new int[] {
                 row,
-                midIndex,
-            }; else if (arr[row][midIndex] < target) colStart =
-                midIndex + 1; else colEnd = midIndex - 1;
+                midIndex, }; 
+            } else if (arr[row][midIndex] < target) { 
+                branchesReached.add("8.1.2");
+                colStart = midIndex + 1; 
+            } else {
+                colEnd = midIndex - 1;
+            }
         }
 
         return new int[] { -1, -1 };

--- a/src/test/java/com/thealgorithms/searches/BinarySearch2dArrayTest.java
+++ b/src/test/java/com/thealgorithms/searches/BinarySearch2dArrayTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+
 
 public class BinarySearch2dArrayTest {
 
@@ -96,5 +98,10 @@ public class BinarySearch2dArrayTest {
         System.out.println(Arrays.toString(ans));
         assertEquals(-1, ans[0]);
         assertEquals(-1, ans[1]);
+    }
+
+    @AfterAll
+    static void printCoverage() {
+        System.out.println("branches reached: " + BinarySearch2dArray.branchesReached);
     }
 }


### PR DESCRIPTION
In the BinarySearch2dArray class.
- added id branch tracking
- added print reached branches to console in Test file

I'm confused about one thing though, which is the sequence in which the ids are added to the HashSet. 
this is a print from a test run:
`branches reached: [8.1.1, 2.1, 8.1.2, 4.1, 5.1, 6.1, 7.1, 8.1, 7.2, 2.1.3, 2.1.2]`

`8.1` is a top level while loop. So I don't understand how `8.1.1` and `8.1.2` has been added to the HashSet before `8.1`...?
