### PR TITLE
refactor: ValidParantheses:isValid, issue #26

### DIFF
--- a/src/main/java/com/thealgorithms/strings/ValidParentheses.java
+++ b/src/main/java/com/thealgorithms/strings/ValidParentheses.java
@@ -10,24 +10,27 @@ public class ValidParentheses {
 	public static boolean isValid(String s) {
 		char[] stack = new char[s.length()];
 		int head = 0;
-		for(char c : s.toCharArray()) {
-			switch(c) {
-				case '{':
-				case '[':
-				case '(':
-					stack[head++] = c;
-					break;
-				case '}':
-					if(head == 0 || stack[--head] != '{') return false;
-					break;
-				case ')':
-					if(head == 0 || stack[--head] != '(') return false;
-					break;
-				case ']':
-					if(head == 0 || stack[--head] != '[') return false;
-					break;
+		for (char c : s.toCharArray()) {
+			if (OpenBracket(c)) {
+				stack[head++] = c;
+			} else if (CloseBracket(c)) {
+				if (head == 0 || !matches(stack[--head], c)) {
+					return false;
+				}
 			}
 		}
 		return head == 0;
+	}
+
+	private static boolean OpenBracket(char c1){
+		return c1 == '(' || c1 == '{' || c1 == '[';
+	}
+
+	private static boolean CloseBracket(char c2){
+		return c2 == ')' || c2 == '}' || c2 == ']';
+	}
+
+	private static boolean matches(char c1, char c2) {
+		return (c1 == '(' && c2 == ')') || (c1 == '{' && c2 == '}') || (c1 == '[' && c2 == ']');
 	}
 }


### PR DESCRIPTION
The CCN for ValidParentheses::isValid was 14 before the refactoring, and after became 6 according to the Lizard tool.